### PR TITLE
请升级commons-codec:commons-codec组件版本以解决1个安全漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,7 @@
         <dependency>
             <groupId>com.konghq</groupId>
             <artifactId>unirest-java</artifactId>
-            <version>3.13.6</version>
-            <classifier>standalone</classifier>
+            <version>4.0.0-RC2</version>          <classifier>standalone</classifier>
         </dependency>
         <!--GSON-->
         <dependency>


### PR DESCRIPTION
将 **com.konghq:unirest-java** 组件从3.13.6 版本升级至 4.0.0-RC2版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2022-11853](https://www.oscs1024.com/hd/MPS-2022-11853) | commons-codec:commons-codec 存在信息泄露漏洞 | 低危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
